### PR TITLE
fix: remove duplicates in range_mcrapter

### DIFF
--- a/pyraptor/model/structures.py
+++ b/pyraptor/model/structures.py
@@ -649,11 +649,6 @@ class Journey:
 
     legs: List[Leg] = field(default_factory=list)
 
-    @property
-    def criteria(self):
-        """Criteria"""
-        return [self.travel_time(), self.fare(), self.number_of_trips()]
-
     def __len__(self):
         return len(self.legs)
 

--- a/pyraptor/query_range_mcraptor.py
+++ b/pyraptor/query_range_mcraptor.py
@@ -173,11 +173,15 @@ def run_range_mcraptor(
 
     logger.info(f"Journey calculation time: {perf_counter() - s}")
 
-    # Keep Pareto-optimal journeys
+    # Keep unique journeys
     for destination_station_name, journeys in journeys_to_destinations.items():
-        best_journeys = pareto_set(journeys, keep_equal=True)
-        journeys_to_destinations[destination_station_name] = best_journeys
+        unique_journeys = []
+        for journey in journeys:
+            if not journey in unique_journeys:
+                unique_journeys.append(journey)
 
+        journeys_to_destinations[destination_station_name] = unique_journeys
+        
     return journeys_to_destinations
 
 


### PR DESCRIPTION
In query mcraptor we constructed non-dominating journeys for multiple departure times and subsequently removed the non dominated options. However, we only want to remove dominated journeys constructed for the same departure times. At large stations where almost every minute a train departures this results in duplicates journeys, they are now removed.
Moreover, the property criteria in Journeys are removed for clarity since they are not used anymore.