### PR TITLE
Fix round error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ pytest-cov = "^2.10.1"
 black = {version = "^20.8b1", allow-prereleases = true}
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core==1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.semantic_release]

--- a/pyraptor/model/raptor.py
+++ b/pyraptor/model/raptor.py
@@ -33,7 +33,8 @@ class Label:
         return self.earliest_arrival_time <= other.earliest_arrival_time
 
     def __repr__(self) -> str:
-        return f"Label(earliest_arrival_time={self.earliest_arrival_time}, trip={self.trip}, from_stop={self.from_stop})"
+        return f"Label(earliest_arrival_time={self.earliest_arrival_time}, trip={self.trip}, " \
+               f"from_stop={self.from_stop})"
 
 
 class RaptorAlgorithm:
@@ -43,7 +44,7 @@ class RaptorAlgorithm:
         self.timetable = timetable
         self.bag_star = None
 
-    def run(self, from_stops, dep_secs, rounds) -> Dict[int, Dict[Stop, Label]]:
+    def run(self, from_stops, dep_secs, rounds) -> Dict[Stop, Label]:
         """Run Round-Based Algorithm"""
 
         # Initialize empty bag of labels, i.e. B_k(p) = Label() for every k and p
@@ -67,6 +68,7 @@ class RaptorAlgorithm:
             marked_stops.append(from_stop)
 
         # Run rounds
+        k = 0
         for k in range(1, rounds + 1):
             logger.info(f"Analyzing possibilities round {k}")
             bag_round_stop[k] = deepcopy(bag_round_stop[k - 1])
@@ -95,9 +97,9 @@ class RaptorAlgorithm:
             else:
                 break
 
-        logger.info("Finish round-based algorithm to create bag with best labels")   
+        logger.info("Finish round-based algorithm to create bag with best labels")
 
-        return bag_round_stop
+        return bag_round_stop[k]
 
     def accumulate_routes(self, marked_stops: List[Stop]) -> List[Tuple[Route, Stop]]:
         """Accumulate routes serving marked stops from previous round, i.e. Q"""

--- a/pyraptor/query_range_raptor.py
+++ b/pyraptor/query_range_raptor.py
@@ -152,8 +152,7 @@ def run_range_raptor(
 
         # Run Round-Based Algorithm
         raptor = RaptorAlgorithm(timetable)
-        bag_round_stop = raptor.run(from_stops, dep_secs, rounds)
-        best_labels = bag_round_stop[rounds]
+        best_labels = raptor.run(from_stops, dep_secs, rounds)
 
         # Determine the best destination ID, destination is a platform
         for destination_station_name, to_stops in destination_stops.items():

--- a/pyraptor/query_raptor.py
+++ b/pyraptor/query_raptor.py
@@ -111,8 +111,7 @@ def run_raptor(
 
     # Run Round-Based Algorithm
     raptor = RaptorAlgorithm(timetable)
-    bag_round_stop = raptor.run(from_stops, dep_secs, rounds)
-    best_labels = bag_round_stop[rounds]
+    best_labels = raptor.run(from_stops, dep_secs, rounds)
 
     # Determine the best journey to all possible destination stations
     journey_to_destinations = dict()


### PR DESCRIPTION
Raptor.run now only returns the final dictionary instead of the results for each round. This way, it is also easier to return the end result if less rounds than specified are required.